### PR TITLE
Implement shared toolbar

### DIFF
--- a/packages/quill/src/modules/shared-toolbar.ts
+++ b/packages/quill/src/modules/shared-toolbar.ts
@@ -1,0 +1,46 @@
+import Quill from '../core/quill.js';
+import Toolbar, { type ToolbarProps } from './toolbar.js';
+
+/**
+ * SharedToolbar allows multiple Quill editors to share a single toolbar.
+ * The toolbar will operate on the editor that is currently focused.
+ */
+export default class SharedToolbar {
+  toolbar: Toolbar;
+  active: Quill;
+  updateHandler: () => void;
+
+  constructor(
+    editors: Quill[],
+    options: Partial<ToolbarProps> & { container: HTMLElement | string },
+  ) {
+    if (editors.length === 0) {
+      throw new Error('SharedToolbar requires at least one editor');
+    }
+    this.toolbar = new Toolbar(editors[0], options);
+    this.active = editors[0];
+    this.updateHandler = () => {
+      const [range] = this.active.selection.getRange();
+      this.toolbar.update(range);
+    };
+    this.active.off(Quill.events.EDITOR_CHANGE, this.updateHandler);
+    this.active.on(Quill.events.EDITOR_CHANGE, this.updateHandler);
+
+    editors.forEach((editor) => {
+      editor.on(Quill.events.SELECTION_CHANGE, (range, _old, source) => {
+        if (range && source === Quill.sources.USER) {
+          this.setActiveEditor(editor);
+        }
+      });
+    });
+  }
+
+  setActiveEditor(editor: Quill) {
+    if (this.active === editor) return;
+    this.active.off(Quill.events.EDITOR_CHANGE, this.updateHandler);
+    this.toolbar.quill = editor;
+    this.active = editor;
+    this.active.on(Quill.events.EDITOR_CHANGE, this.updateHandler);
+    this.updateHandler();
+  }
+}

--- a/packages/quill/src/quill.ts
+++ b/packages/quill/src/quill.ts
@@ -40,6 +40,7 @@ import CodeBlock, { Code as InlineCode } from './formats/code.js';
 import Syntax from './modules/syntax.js';
 import Table from './modules/table.js';
 import Toolbar from './modules/toolbar.js';
+import SharedToolbar from './modules/shared-toolbar.js';
 
 import Icons from './ui/icons.js';
 import Picker from './ui/picker.js';
@@ -102,6 +103,7 @@ Quill.register(
     'modules/syntax': Syntax,
     'modules/table': Table,
     'modules/toolbar': Toolbar,
+    'modules/shared-toolbar': SharedToolbar,
 
     'themes/bubble': BubbleTheme,
     'themes/snow': SnowTheme,
@@ -131,5 +133,6 @@ export type {
   ExpandedQuillOptions,
   QuillOptions,
 };
+export { SharedToolbar };
 
 export default Quill;

--- a/packages/website/content/docs/modules/toolbar.mdx
+++ b/packages/website/content/docs/modules/toolbar.mdx
@@ -241,3 +241,16 @@ const quill = new Quill('#editor', {
 const toolbar = quill.getModule('toolbar');
 toolbar.addHandler('image', showImageUI);
 ```
+
+## Shared toolbar across editors
+
+Multiple Quill instances can share a single toolbar using the `SharedToolbar` module. Create your editors without toolbars and then attach `SharedToolbar` to them:
+
+```javascript
+const editor1 = new Quill('#editor1', { modules: { toolbar: false }, theme: 'snow' });
+const editor2 = new Quill('#editor2', { modules: { toolbar: false }, theme: 'snow' });
+
+const shared = new Quill.SharedToolbar([editor1, editor2], { container: '#toolbar' });
+```
+
+The toolbar will act on whichever editor is focused.


### PR DESCRIPTION
## Summary
- add `SharedToolbar` module for managing multiple editors with one toolbar
- register new module in Quill exports and document usage
- document shared toolbar usage in toolbar guide

## Testing
- `npm run lint -w quill`
- `npm test -w quill` *(fails: Host system missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688ac29c013883238fce91a42ff3e51d